### PR TITLE
Fix security/detect-object-injection lint warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ Baruch is a Cloudflare Worker that powers an AI configuration assistant. Instead
 - Never run `wrangler deploy` directly — all deploys through CI/CD
 - Never merge a PR without user permission
 - Never commit secrets or `.dev.vars`
+- Never let security lint warnings (e.g. `security/detect-object-injection`) slide — fix the code or add an `eslint-disable-next-line` with a justification comment before merging
 
 ### Code Quality (Fitness Functions)
 

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -5,7 +5,9 @@ export function constantTimeCompare(a: string, b: string): boolean {
   const maxLength = Math.max(aBytes.length, bBytes.length);
   let result = aBytes.length ^ bBytes.length;
   for (let i = 0; i < maxLength; i++) {
+    // eslint-disable-next-line security/detect-object-injection -- i is a bounds-checked numeric loop index
     const aByte = i < aBytes.length ? aBytes[i]! : 0;
+    // eslint-disable-next-line security/detect-object-injection -- i is a bounds-checked numeric loop index
     const bByte = i < bBytes.length ? bBytes[i]! : 0;
     result |= aByte ^ bByte;
   }

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -10,7 +10,8 @@ export function replaceTemplateVariables(
   variables: Record<string, string> = TEMPLATE_VARIABLES
 ): string {
   return text.replace(/\{\{(\w+)\}\}/g, (match, name: string) => {
-    const value = variables[name];
+    // eslint-disable-next-line security/detect-object-injection -- name is from \w+ regex (word chars only); Object.hasOwn guards prototype access
+    const value = Object.hasOwn(variables, name) ? variables[name] : undefined;
     return value !== undefined ? value : match;
   });
 }
@@ -20,6 +21,7 @@ export function applyTemplateVariables(
 ): Required<Record<PromptSlot, string>> {
   const result = { ...resolved };
   for (const slot of PROMPT_OVERRIDE_SLOTS) {
+    // eslint-disable-next-line security/detect-object-injection -- slot is from PROMPT_OVERRIDE_SLOTS constant
     result[slot] = replaceTemplateVariables(result[slot]);
   }
   return result;


### PR DESCRIPTION
## Summary

- `template.ts`: add `Object.hasOwn` guard on variable lookup (prevents prototype pollution); suppress false positive on `PROMPT_OVERRIDE_SLOTS` slot access with justification
- `crypto.ts`: suppress false positives on bounds-checked numeric loop index accesses with justification
- `CLAUDE.md`: add rule to never let security lint warnings slide without resolution

## Test plan

- [x] `pnpm lint` — clean, no warnings
- [x] All 168 unit tests pass
- [x] `pnpm check` and `pnpm architecture` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)